### PR TITLE
Relax contraints on xmpp4r

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.5
+  - Relax constraints on xmpp4r to be able to install both the input and the output at the same time
+
 ## 3.0.2
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/logstash-output-xmpp.gemspec
+++ b/logstash-output-xmpp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-xmpp'
-  s.version         = '3.0.4'
+  s.version         = '3.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output allows you ship events over XMPP/Jabber"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
-  s.add_runtime_dependency 'xmpp4r', ['0.5.6']
+  s.add_runtime_dependency 'xmpp4r', '~> 0.5.6'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
We have to relax the constraints on xmpp4r to be able to install the
output and the input at the same time.
