### PR TITLE
Don't crash logstash with an exception if XMPP becomes unavailable

### DIFF
--- a/lib/logstash/outputs/xmpp.rb
+++ b/lib/logstash/outputs/xmpp.rb
@@ -51,6 +51,7 @@ class LogStash::Outputs::Xmpp < LogStash::Outputs::Base
   public
   def connect
     Jabber::debug = true
+    Thread::abort_on_exception = false
     client = Jabber::Client.new(Jabber::JID.new(@user))
     client.connect(@host)
     client.auth(@password.value)


### PR DESCRIPTION
Prevent Logstash from crashing if XMPP/Jabber becomes unavailable.

This is only a partial fix for #7, as XMPP/Jabber must still be working when Logstash is _started_.